### PR TITLE
トップページのid属性をトップページ以外につけるようにした

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
       <p class="alert alert-error"><%= alert %></p>
     <% end %>
 
-    <div class="" id="margin-down-top<%= '-toppage' if current_page?(root_path) %>">
+    <div id=<%= "margin-down-top" unless current_page?(root_path) %>>
       <%= yield %>
     </div>
 


### PR DESCRIPTION
@norotime
#41 
使っていないclassを削除して、id名をトップページで付けないようにしてみました。